### PR TITLE
update eupspkg.cfg.sh to curl the new SED library from lsst-dev

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -2,7 +2,7 @@ install()
 {
     default_install
     cd $PREFIX
-    curl -O "http://lsst-web.ncsa.illinois.edu/~krughoff/data/seds_100614.tar.gz"
-    tar zxvf seds_100614.tar.gz
-    rm seds_100614.tar.gz
+    curl -O "https://lsst-web.ncsa.illinois.edu/sim-data/sed_library/seds_160112.tar.gz"
+    tar zxvf seds_160112.tar.gz
+    rm seds_160112.tar.gz
 }


### PR DESCRIPTION
This is just a stop-gap measure until we can get an lfs repository up for sims_sed_library.  For now, we will just curl down a tar file containing all of the model SEDs from lsst-dev.
