### PR TITLE
bugfix/SIM-1732/mltPhoSim

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -2,7 +2,7 @@ install()
 {
     default_install
     cd $PREFIX
-    curl -O "https://lsst-web.ncsa.illinois.edu/sim-data/sed_library/seds_160112.tar.gz"
-    tar zxvf seds_160112.tar.gz
-    rm seds_160112.tar.gz
+    curl -O "https://lsst-web.ncsa.illinois.edu/sim-data/sed_library/seds_160126.tar.gz"
+    tar zxvf seds_160126.tar.gz
+    rm seds_160126.tar.gz
 }


### PR DESCRIPTION
When we updated the sims_sed_library last week, the MLT dwarves were matched to SED files each with 58,500 lines in them.  PhoSim only allows SED files to have 24,999 lines in them, so I added a sub-folder to sims_sed_library/starSED/ that contains the MLT dwarf spectra clipped to meet this requirement.  I then wrote a SpecFileMap sub-class specifically for the PhoSim InstanceCatalogs so that MLT dwarf spectra names get mapped to that sub-directory.

There are pull requests in

sims_utils
sims_catalogs_measures
sims_catUtils
sims_sed_library

supporting this pull request
